### PR TITLE
Increase Test Speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            ./gradlew SDKAndroid:testDebugUnitTest
             ./gradlew koverXmlReport
       - store_artifacts:
           path: SDKAndroid/build/reports/kover/project-xml/report.xml


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [X] Feature
- [ ] Bug fix

### Linked issue

- [X] Not tracked

### Why

Removing previus unitTesting inrease a lot of the CI speed

### How

Kover plugin automatically run the command when generate tje XML Coverage report

### Screens

Increase performace with 40 secods more faster!

<img width="1527" alt="Captura de Pantalla 2022-06-02 a la(s) 13 21 27" src="https://user-images.githubusercontent.com/7268597/171699744-27ab954c-f2ce-47ef-b706-8e597e239754.png">


