### PR TITLE
New Envs for SDK and DemoApp

### DIFF
--- a/SDKAndroid/build.gradle
+++ b/SDKAndroid/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     // -- Cybrid API Bank
-    implementation('app.cybrid:cybrid-api-bank-kotlin:0.62.0') {
+    implementation('app.cybrid:cybrid-api-bank-kotlin:0.62.55') {
         exclude group:'org.apache.oltu.oauth2', module: 'org.apache.oltu.oauth2.common'
     }
 

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/AppModule.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/AppModule.kt
@@ -16,6 +16,6 @@ object AppModule {
     }
 
     internal fun getApiUrl(): String {
-        return String.format(baseUrl, Cybrid.instance.env.name)
+        return String.format(baseUrl, Cybrid.instance.env.name.lowercase())
     }
 }

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/AppModule.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/AppModule.kt
@@ -13,7 +13,7 @@ object AppModule {
         )
     }
 
-    private fun getApiUrl() : String {
+    internal fun getApiUrl() : String {
 
         val envURL = when(Cybrid.instance.env) {
 

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/AppModule.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/AppModule.kt
@@ -4,6 +4,8 @@ import app.cybrid.cybrid_api_bank.client.infrastructure.ApiClient
 
 object AppModule {
 
+    private const val baseUrl = "https://bank.%s.cybrid.app"
+
     fun getClient(): ApiClient {
 
         val clientBuilder = Cybrid.instance.getOKHttpClient()
@@ -13,14 +15,7 @@ object AppModule {
         )
     }
 
-    internal fun getApiUrl() : String {
-
-        val envURL = when(Cybrid.instance.env) {
-
-            CybridEnv.STAGING -> "https://bank.staging.cybrid.app"
-            CybridEnv.SANDBOX -> "https://bank.sandbox.cybrid.app"
-            CybridEnv.PRODUCTION -> "https://bank.production.cybrid.app"
-        }
-        return envURL
+    internal fun getApiUrl(): String {
+        return String.format(baseUrl, Cybrid.instance.env.name)
     }
 }

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/AppModule.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/AppModule.kt
@@ -4,9 +4,23 @@ import app.cybrid.cybrid_api_bank.client.infrastructure.ApiClient
 
 object AppModule {
 
-    fun getClient() : ApiClient {
+    fun getClient(): ApiClient {
 
-        val clientBuilder = Cybrid.instance.let { it.getOKHttpClient() }
-        return ApiClient(okHttpClientBuilder = clientBuilder)
+        val clientBuilder = Cybrid.instance.getOKHttpClient()
+        return ApiClient(
+            baseUrl = getApiUrl(),
+            okHttpClientBuilder = clientBuilder
+        )
+    }
+
+    private fun getApiUrl() : String {
+
+        val envURL = when(Cybrid.instance.env) {
+
+            CybridEnv.STAGING -> "https://bank.staging.cybrid.app"
+            CybridEnv.SANDBOX -> "https://bank.sandbox.cybrid.app"
+            CybridEnv.PRODUCTION -> "https://bank.production.cybrid.app"
+        }
+        return envURL
     }
 }

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/Cybrid.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/Cybrid.kt
@@ -17,7 +17,7 @@ open class Cybrid {
     var listener: CybridSDKEvents? = null
     var imagesUrl = "https://images.cybrid.xyz/sdk/assets/png/color/"
     var imagesSize = "@2x.png"
-    var env = CybridEnv.STAGING
+    var env = CybridEnv.SANDBOX
 
     var accountsRefreshObservable = MutableStateFlow(false)
 

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/Cybrid.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/Cybrid.kt
@@ -17,6 +17,7 @@ open class Cybrid {
     var listener: CybridSDKEvents? = null
     var imagesUrl = "https://images.cybrid.xyz/sdk/assets/png/color/"
     var imagesSize = "@2x.png"
+    var env = CybridEnv.STAGING
 
     var accountsRefreshObservable = MutableStateFlow(false)
 
@@ -38,3 +39,4 @@ open class Cybrid {
         val instance = Cybrid()
     }
 }
+enum class CybridEnv { STAGING, SANDBOX, PRODUCTION }

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/components/kyc/view/IdentityVerificationViewModel.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/components/kyc/view/IdentityVerificationViewModel.kt
@@ -184,8 +184,6 @@ class IdentityVerificationViewModel: ViewModel() {
                                 verification = recordResponse.data
                                 return@async verification
                             } else {
-                                Log.d("DXGOP", "ERROR: " + it.message)
-                                Log.d("DXGOP", "ERROR: " + it.raw?.message)
                                 return@async null
                             }
                         }

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/components/kyc/view/IdentityVerificationViewModel.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/components/kyc/view/IdentityVerificationViewModel.kt
@@ -1,5 +1,6 @@
 package app.cybrid.sdkandroid.components.kyc.view
 
+import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -11,11 +12,8 @@ import app.cybrid.cybrid_api_bank.client.infrastructure.ApiClient
 import app.cybrid.cybrid_api_bank.client.models.*
 import app.cybrid.sdkandroid.Cybrid
 import app.cybrid.sdkandroid.components.KYCView
-import app.cybrid.sdkandroid.util.Logger
-import app.cybrid.sdkandroid.util.LoggerEvents
-import app.cybrid.sdkandroid.util.Polling
+import app.cybrid.sdkandroid.util.*
 import java.math.BigDecimal as JavaBigDecimal
-import app.cybrid.sdkandroid.util.getResult
 import kotlinx.coroutines.*
 
 class IdentityVerificationViewModel: ViewModel() {
@@ -94,9 +92,13 @@ class IdentityVerificationViewModel: ViewModel() {
                             lastVerification = createIdentityVerification()
                         }
 
-                        val lastVerificationWithDetails = fetchIdentityVerificationWithDetailsStatus(guid = lastVerification?.guid!!)
-                        val returnedWrapper = IdentityVerificationWrapper(identity = lastVerification, details = lastVerificationWithDetails)
-                        checkIdentityRecordStatus(returnedWrapper)
+                        if (lastVerification == null) {
+                            uiState?.value = KYCView.KYCViewState.ERROR
+                        } else {
+                            val lastVerificationWithDetails = fetchIdentityVerificationWithDetailsStatus(guid = lastVerification?.guid!!)
+                            val returnedWrapper = IdentityVerificationWrapper(identity = lastVerification, details = lastVerificationWithDetails)
+                            checkIdentityRecordStatus(returnedWrapper)
+                        }
                     }
                 }
             }
@@ -176,9 +178,17 @@ class IdentityVerificationViewModel: ViewModel() {
                                 )
                             )
                         }
-                        Logger.log(LoggerEvents.DATA_FETCHED, "Create - Identity Verification")
-                        verification = recordResponse.data
-                        return@async verification
+                        recordResponse.let {
+                            if (isSuccessful(it.code ?: 500)) {
+                                Logger.log(LoggerEvents.DATA_FETCHED, "Create - Identity Verification")
+                                verification = recordResponse.data
+                                return@async verification
+                            } else {
+                                Log.d("DXGOP", "ERROR: " + it.message)
+                                Log.d("DXGOP", "ERROR: " + it.raw?.message)
+                                return@async null
+                            }
+                        }
                     }
                     waitFor.await()
                 }

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/util/DataAccessStrategy.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/util/DataAccessStrategy.kt
@@ -25,7 +25,6 @@ suspend fun <T> getResult(call: suspend() -> Response<T>): Resource<T> {
                 cybrid.listener.let {
                     cybrid.invalidToken = true
                     it?.onTokenExpired()
-
                 }
             }
             Logger.log(LoggerEvents.AUTH_EXPIRED, "${response.code()} - ${response.message()}")

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/util/DataAccessStrategy.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/util/DataAccessStrategy.kt
@@ -34,7 +34,8 @@ suspend fun <T> getResult(call: suspend() -> Response<T>): Resource<T> {
             return Resource.error(
                 message = response.message(),
                 data = response.body(),
-                code = response.code()
+                code = response.code(),
+                raw = response.raw()
             )
         }
     } catch (e: Exception) {

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/util/Resource.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/util/Resource.kt
@@ -1,21 +1,24 @@
 package app.cybrid.sdkandroid.util
 
-data class Resource<out T>(val status: Status, val data: T?, val message: String?, val code: Int?) {
+import okhttp3.Response
+import okhttp3.ResponseBody
+
+data class Resource<out T>(val status: Status, val data: T?, val message: String?, val code: Int?, val raw: Response?) {
 
   enum class Status { SUCCESS, ERROR, LOADING }
 
   companion object {
 
     fun <T> success(data: T, code: Int) : Resource<T> {
-      return Resource(Status.SUCCESS, data, null, code)
+      return Resource(Status.SUCCESS, data, null, code, null)
     }
 
-    fun <T> error(message:String, data: T? = null, code: Int? = 500) : Resource<T> {
-      return Resource(Status.ERROR, data, message, code)
+    fun <T> error(message:String, data: T? = null, code: Int? = 500, raw: Response? = null) : Resource<T> {
+      return Resource(Status.ERROR, data, message, code, raw)
     }
 
     fun <T> loading() : Resource<T> {
-      return Resource(Status.LOADING, null, null, null)
+      return Resource(Status.LOADING, null, null, null, null)
     }
   }
 }

--- a/SDKAndroid/src/test/java/app/cybrid/sdkandroid/AppModuleTest.kt
+++ b/SDKAndroid/src/test/java/app/cybrid/sdkandroid/AppModuleTest.kt
@@ -25,4 +25,23 @@ class AppModuleTest {
         // -- Client works
         assertNotNull(client)
     }
+
+    @Test
+    fun test_getApiUrl() {
+
+        // -- Staging
+        Cybrid.instance.env = CybridEnv.STAGING
+        val stagingURL = AppModule.getApiUrl()
+        assertTrue(stagingURL.contains("staging"))
+
+        // -- Staging
+        Cybrid.instance.env = CybridEnv.SANDBOX
+        val sandboxURL = AppModule.getApiUrl()
+        assertTrue(sandboxURL.contains("sandbox"))
+
+        // -- Production
+        Cybrid.instance.env = CybridEnv.PRODUCTION
+        val productionURL = AppModule.getApiUrl()
+        assertTrue(productionURL.contains("production"))
+    }
 }

--- a/SDKAndroid/src/test/java/app/cybrid/sdkandroid/tools/ErrorMockInterceptor.kt
+++ b/SDKAndroid/src/test/java/app/cybrid/sdkandroid/tools/ErrorMockInterceptor.kt
@@ -14,7 +14,7 @@ class ErrorMockInterceptor(code: Int) : Interceptor {
 
             return chain.proceed(chain.request())
                 .newBuilder()
-                .code(403)
+                .code(responseCode)
                 .request(chain.request())
                 .protocol(Protocol.HTTP_2)
                 .build()

--- a/SDKAndroid/src/test/java/app/cybrid/sdkandroid/util/DataAccessStrategyTest.kt
+++ b/SDKAndroid/src/test/java/app/cybrid/sdkandroid/util/DataAccessStrategyTest.kt
@@ -131,4 +131,19 @@ class DataAccessStrategyTest {
         Assert.assertEquals(result.code, expectedCode)
         Assert.assertEquals(result, resourceToCheck)
     }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun test_getResult_Error() = runBlocking {
+
+        val expectedCode = HttpURLConnection.HTTP_INTERNAL_ERROR
+        val apiClient = prepareClient(expectedCode)
+        Cybrid.instance.setBearer(TestConstants.expiredToken)
+
+        val pricesService = apiClient.createService(PricesApi::class.java)
+        val result = getResult { pricesService.listPrices() }
+
+        Assert.assertNotNull(result)
+        Assert.assertEquals(result.code, expectedCode)
+    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "app.cybrid.demoapp"
         minSdk 26
         targetSdk 33
-        versionCode 6
-        versionName "1.0.6"
+        versionCode 7
+        versionName "1.0.7"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/app/cybrid/demoapp/api/auth/entity/TokenRequest.kt
+++ b/app/src/main/java/app/cybrid/demoapp/api/auth/entity/TokenRequest.kt
@@ -14,5 +14,5 @@ data class TokenRequest (
     var client_secret:String,
 
     @SerializedName("scope")
-    var scope:String = "banks:read banks:write accounts:read accounts:execute customers:read customers:write customers:execute prices:read quotes:execute trades:execute trades:read workflows:execute workflows:read external_bank_accounts:execute external_bank_accounts:read transfers:read transfers:execute"
+    var scope:String = "banks:read banks:write banks:execute accounts:read accounts:execute customers:read customers:write customers:execute prices:read quotes:execute trades:execute trades:read workflows:execute workflows:read external_bank_accounts:execute external_bank_accounts:read transfers:read transfers:execute"
 )

--- a/app/src/main/java/app/cybrid/demoapp/api/auth/entity/TokenRequest.kt
+++ b/app/src/main/java/app/cybrid/demoapp/api/auth/entity/TokenRequest.kt
@@ -14,5 +14,5 @@ data class TokenRequest (
     var client_secret:String,
 
     @SerializedName("scope")
-    var scope:String = "banks:read banks:write banks:execute accounts:read accounts:execute customers:read customers:write customers:execute prices:read quotes:execute trades:execute trades:read workflows:execute workflows:read external_bank_accounts:execute external_bank_accounts:read transfers:read transfers:execute"
+    var scope:String = "banks:read banks:write accounts:read accounts:execute customers:read customers:write customers:execute prices:read quotes:execute trades:execute trades:read workflows:execute workflows:read external_bank_accounts:execute external_bank_accounts:read transfers:read transfers:execute"
 )

--- a/app/src/main/java/app/cybrid/demoapp/core/App.kt
+++ b/app/src/main/java/app/cybrid/demoapp/core/App.kt
@@ -39,7 +39,7 @@ class App : Application(), CybridSDKEvents {
     fun setupCybridSDK() {
 
         Cybrid.instance.listener = this
-        Cybrid.instance.env = CybridEnv.SANDBOX
+        Cybrid.instance.env = demonEnv
         if (Cybrid.instance.customerGuid == "") {
             Cybrid.instance.customerGuid = BuildConfig.CUSTOMER_GUID
         }
@@ -92,7 +92,8 @@ class App : Application(), CybridSDKEvents {
 
     companion object {
 
-        const val demoUrl = "https://id.sandbox.cybrid.app"
+        private val demonEnv = CybridEnv.SANDBOX
+        private val demoUrl = "https://id.${demonEnv.name}.cybrid.app"
         const val TAG = "CybridSDKDemo"
 
         @SuppressLint("StaticFieldLeak")

--- a/app/src/main/java/app/cybrid/demoapp/core/App.kt
+++ b/app/src/main/java/app/cybrid/demoapp/core/App.kt
@@ -39,7 +39,7 @@ class App : Application(), CybridSDKEvents {
     fun setupCybridSDK() {
 
         Cybrid.instance.listener = this
-        Cybrid.instance.env = CybridEnv.STAGING
+        Cybrid.instance.env = CybridEnv.SANDBOX
         if (Cybrid.instance.customerGuid == "") {
             Cybrid.instance.customerGuid = BuildConfig.CUSTOMER_GUID
         }
@@ -92,7 +92,7 @@ class App : Application(), CybridSDKEvents {
 
     companion object {
 
-        const val demoUrl = "https://id.staging.cybrid.app"
+        const val demoUrl = "https://id.sandbox.cybrid.app"
         const val TAG = "CybridSDKDemo"
 
         @SuppressLint("StaticFieldLeak")

--- a/app/src/main/java/app/cybrid/demoapp/core/App.kt
+++ b/app/src/main/java/app/cybrid/demoapp/core/App.kt
@@ -15,6 +15,7 @@ import app.cybrid.demoapp.api.auth.entity.TokenResponse
 import app.cybrid.demoapp.api.auth.service.AppService
 import app.cybrid.demoapp.listener.BearerListener
 import app.cybrid.sdkandroid.Cybrid
+import app.cybrid.sdkandroid.CybridEnv
 import app.cybrid.sdkandroid.listener.CybridSDKEvents
 import retrofit2.Call
 import retrofit2.Callback
@@ -38,6 +39,7 @@ class App : Application(), CybridSDKEvents {
     fun setupCybridSDK() {
 
         Cybrid.instance.listener = this
+        Cybrid.instance.env = CybridEnv.STAGING
         if (Cybrid.instance.customerGuid == "") {
             Cybrid.instance.customerGuid = BuildConfig.CUSTOMER_GUID
         }

--- a/app/src/main/java/app/cybrid/demoapp/core/App.kt
+++ b/app/src/main/java/app/cybrid/demoapp/core/App.kt
@@ -90,7 +90,7 @@ class App : Application(), CybridSDKEvents {
 
     companion object {
 
-        const val demoUrl = "https://id.demo.cybrid.app"
+        const val demoUrl = "https://id.staging.cybrid.app"
         const val TAG = "CybridSDKDemo"
 
         @SuppressLint("StaticFieldLeak")

--- a/app/src/main/java/app/cybrid/demoapp/core/App.kt
+++ b/app/src/main/java/app/cybrid/demoapp/core/App.kt
@@ -93,7 +93,7 @@ class App : Application(), CybridSDKEvents {
     companion object {
 
         private val demonEnv = CybridEnv.SANDBOX
-        private val demoUrl = "https://id.${demonEnv.name.lowercase()}.cybrid.app"
+        val demoUrl = "https://id.${demonEnv.name.lowercase()}.cybrid.app"
         const val TAG = "CybridSDKDemo"
 
         @SuppressLint("StaticFieldLeak")

--- a/app/src/main/java/app/cybrid/demoapp/core/App.kt
+++ b/app/src/main/java/app/cybrid/demoapp/core/App.kt
@@ -93,7 +93,7 @@ class App : Application(), CybridSDKEvents {
     companion object {
 
         private val demonEnv = CybridEnv.SANDBOX
-        private val demoUrl = "https://id.${demonEnv.name}.cybrid.app"
+        private val demoUrl = "https://id.${demonEnv.name.lowercase()}.cybrid.app"
         const val TAG = "CybridSDKDemo"
 
         @SuppressLint("StaticFieldLeak")

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-    sdk_version = '0.0.80'
+    sdk_version = '0.0.81'
 }


### PR DESCRIPTION
### Type of change

- [ ] Chore
- [x] Feature
- [ ] Bug fix

### Linked issue

- https://cybrid.atlassian.net/browse/CYB-1100
- https://cybrid.atlassian.net/browse/CYB-1097

### Why

This PR add the way to handle multi api url links for different envs. Add:
- A configurable property when you init the SDK to set the ENV (Staging, Sandbox, Production) 
- Move into Demo App the url for create the bearer token to Sandbox
- Add more test around `getResult {}`
- New keys of Sandbox in CircleCI

### Evidence

https://user-images.githubusercontent.com/7268597/221889441-44502a4b-3c75-456f-9718-a60e39ba38ea.mov
