### PR TITLE
Update AGP, Gradle, Kotlin, Compose, Compiler, JDK, CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,16 +30,20 @@ jobs:
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
+          name: Download Dependencies
+          command: |
+            ./gradlew SDKAndroid:androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      - run:
           name: Run SDK Unit Test
           command: |
             ./gradlew koverXmlReport
       - store_artifacts:
           path: SDKAndroid/build/reports/kover/xml/report.xml
           destination: reports
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - codecov/upload:
           file: 'SDKAndroid/build/reports/kover/xml/report.xml'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@3.2.4
-  android: circleci/android@2.1.2
+  android: circleci/android@2.3.0
 
 parameters:
   GHA_Event:
@@ -22,7 +22,7 @@ jobs:
 
   android-sdk-test:
     docker:
-      - image: cimg/android:2022.09.2
+      - image: cimg/android:2023.06.1
     environment:
       JVM_OPTS: -Xmx3200m
     steps:
@@ -51,7 +51,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: large
-      tag: 2021.10.1
+      tag: 2023.06.1
     steps:
       - checkout
       - android/create-avd:
@@ -71,7 +71,7 @@ jobs:
 
   android-sdk-publish:
     docker:
-      - image: cimg/android:2022.09.2
+      - image: cimg/android:2023.06.1
     environment:
       JVM_OPTS: -Xmx3200m
     steps:
@@ -103,7 +103,7 @@ jobs:
 
   firebase-robo:
     docker:
-      - image: cimg/android:2022.09.2
+      - image: cimg/android:2023.06.1
     environment:
       JVM_OPTS: -Xmx3200m
     steps:
@@ -144,7 +144,7 @@ jobs:
 
   demo-app-publish:
     docker:
-      - image: cimg/android:2022.09.2
+      - image: cimg/android:2023.06.1
     environment:
       JVM_OPTS: -Xmx3200m
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,20 +30,16 @@ jobs:
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
-          name: Download Dependencies
-          command: |
-            ./gradlew SDKAndroid:androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-      - run:
           name: Run SDK Unit Test
           command: |
             ./gradlew koverXmlReport
       - store_artifacts:
           path: SDKAndroid/build/reports/kover/xml/report.xml
           destination: reports
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - codecov/upload:
           file: 'SDKAndroid/build/reports/kover/xml/report.xml'
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,12 +6,8 @@
 
 ### Linked issue
 
-- [ ] Not tracked
-
 ### Why
 
 > Explain why this PR is required
 
-### How
-
-> Explain how this PR addresses the why
+### Evidence

--- a/.github/workflows/release-versioning.yml
+++ b/.github/workflows/release-versioning.yml
@@ -13,3 +13,4 @@ jobs:
       - uses: rymndhng/release-on-push-action@master
         with:
           bump_version_scheme: patch
+          tag_prefix: ""

--- a/SDKAndroid/build.gradle
+++ b/SDKAndroid/build.gradle
@@ -37,15 +37,8 @@ android {
         }
     }
     publishing {
-        singleVariant('release') {
-            withSourcesJar()
-            withJavadocJar()
-        }
-
-        singleVariant('debug') {
-            withSourcesJar()
-            withJavadocJar()
-        }
+        singleVariant('release') {}
+        singleVariant('debug') {}
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/SDKAndroid/build.gradle
+++ b/SDKAndroid/build.gradle
@@ -162,12 +162,12 @@ dependencies {
     ext.retrofitVersion = '2.9.0'
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     // -- Cybrid API Bank
-    implementation('app.cybrid:cybrid-api-bank-kotlin:0.68.33') {
+    implementation('app.cybrid:cybrid-api-bank-kotlin:0.71.68') {
         exclude group:'org.apache.oltu.oauth2', module: 'org.apache.oltu.oauth2.common'
     }
 

--- a/SDKAndroid/build.gradle
+++ b/SDKAndroid/build.gradle
@@ -38,7 +38,10 @@ android {
     }
     publishing {
         singleVariant('release') {}
-        singleVariant('debug') {}
+        singleVariant('debug') {
+            withSourcesJar()
+            withJavadocJar()
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/SDKAndroid/build.gradle
+++ b/SDKAndroid/build.gradle
@@ -58,7 +58,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = '1.3.2'
+        kotlinCompilerExtensionVersion = '1.4.3'
     }
     testOptions {
         unitTests.returnDefaultValues = true

--- a/SDKAndroid/build.gradle
+++ b/SDKAndroid/build.gradle
@@ -27,7 +27,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }
-
     buildTypes {
         debug {
             minifyEnabled false
@@ -35,6 +34,17 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+
+        singleVariant('debug') {
+            withSourcesJar()
+            withJavadocJar()
         }
     }
     compileOptions {
@@ -105,7 +115,42 @@ artifacts {
     archives androidSourcesJar
 }
 
-publishing {
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                groupId 'app.cybrid'
+                artifactId = 'cybrid-android-sdk'
+                version version
+                // artifact androidSourcesJar
+                pom {
+                    name = 'Cybrid Android SDK'
+                    description = 'Android SDK for UI Components'
+                    url = 'https://cybrid.xyz'
+                    licenses {
+                        license {
+                            name = 'Apache-2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'erick-cybrid'
+                            name = 'Erick Sanchez'
+                            email = 'erick.sanchez@cybrid.app'
+                        }
+                    }
+                    scm {
+                        url = 'https://github.com/Cybrid-app/cybrid-sdk-android'
+                    }
+                }
+            }
+        }
+    }
+}
+
+/*publishing {
     publications {
         maven(MavenPublication) {
             groupId 'app.cybrid'
@@ -113,9 +158,9 @@ publishing {
             version version
             afterEvaluate {
                 if (project.plugins.findPlugin("com.android.library")) {
-                    from components.release
+                    components.getByName('release')
                 } else {
-                    from components.java
+                    components.getByName('debug')
                 }
             }
             artifact androidSourcesJar
@@ -137,12 +182,12 @@ publishing {
                     }
                 }
                 scm {
-                    url = 'https://github.com/Cybrid-app/Cybrid-SDK/'
+                    url = 'https://github.com/Cybrid-app/cybrid-sdk-android'
                 }
             }
         }
     }
-}
+}*/
 
 signing {
 

--- a/SDKAndroid/build.gradle
+++ b/SDKAndroid/build.gradle
@@ -99,22 +99,6 @@ kover {
     }
 }
 
-task androidSourcesJar(type: Jar) {
-
-    archiveClassifier.set('sources')
-    if (project.plugins.findPlugin("com.android.library")) {
-        from android.sourceSets.main.java.srcDirs
-        from android.sourceSets.main.kotlin.srcDirs
-    } else {
-        from sourceSets.main.java.srcDirs
-        from sourceSets.main.kotlin.srcDirs
-    }
-}
-
-artifacts {
-    archives androidSourcesJar
-}
-
 afterEvaluate {
     publishing {
         publications {
@@ -123,7 +107,6 @@ afterEvaluate {
                 groupId 'app.cybrid'
                 artifactId = 'cybrid-android-sdk'
                 version version
-                // artifact androidSourcesJar
                 pom {
                     name = 'Cybrid Android SDK'
                     description = 'Android SDK for UI Components'
@@ -149,45 +132,6 @@ afterEvaluate {
         }
     }
 }
-
-/*publishing {
-    publications {
-        maven(MavenPublication) {
-            groupId 'app.cybrid'
-            artifactId = 'cybrid-android-sdk'
-            version version
-            afterEvaluate {
-                if (project.plugins.findPlugin("com.android.library")) {
-                    components.getByName('release')
-                } else {
-                    components.getByName('debug')
-                }
-            }
-            artifact androidSourcesJar
-            pom {
-                name = 'Cybrid Android SDK'
-                description = 'Android SDK for UI Components'
-                url = 'https://cybrid.xyz'
-                licenses {
-                    license {
-                        name = 'Apache-2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id = 'erick-cybrid'
-                        name = 'Erick Sanchez'
-                        email = 'erick.sanchez@cybrid.app'
-                    }
-                }
-                scm {
-                    url = 'https://github.com/Cybrid-app/cybrid-sdk-android'
-                }
-            }
-        }
-    }
-}*/
 
 signing {
 

--- a/SDKAndroid/src/main/java/app/cybrid/sdkandroid/components/kyc/view/IdentityVerificationViewModel.kt
+++ b/SDKAndroid/src/main/java/app/cybrid/sdkandroid/components/kyc/view/IdentityVerificationViewModel.kt
@@ -95,7 +95,7 @@ class IdentityVerificationViewModel: ViewModel() {
                         if (lastVerification == null) {
                             uiState?.value = KYCView.KYCViewState.ERROR
                         } else {
-                            val lastVerificationWithDetails = fetchIdentityVerificationWithDetailsStatus(guid = lastVerification?.guid!!)
+                            val lastVerificationWithDetails = fetchIdentityVerificationWithDetailsStatus(guid = lastVerification.guid!!)
                             val returnedWrapper = IdentityVerificationWrapper(identity = lastVerification, details = lastVerificationWithDetails)
                             checkIdentityRecordStatus(returnedWrapper)
                         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     ext.retrofitVersion = '2.9.0'
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation project(path: ':SDKAndroid')

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.2' apply false
-    id 'com.android.library' version '7.4.2' apply false
+    id 'com.android.application' version '8.0.2' apply false
+    id 'com.android.library' version '8.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
     id 'org.jetbrains.kotlinx.kover' version "0.6.1"
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply true

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     id 'com.android.application' version '8.0.2' apply false
     id 'com.android.library' version '8.0.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
     id 'org.jetbrains.kotlinx.kover' version "0.6.1"
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
     id 'org.jetbrains.kotlinx.kover' version "0.6.1"
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply true

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,7 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
+
+org.gradle.daemon=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Tue Jun 06 09:34:22 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-    sdk_version = '0.0.81'
+    sdk_version = '0.0.84'
 }

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-    sdk_version = '0.0.84'
+    sdk_version = '0.0.85'
 }

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-    sdk_version = '0.0.87'
+    sdk_version = '0.0.88'
 }

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-    sdk_version = '0.0.85'
+    sdk_version = '0.0.87'
 }


### PR DESCRIPTION
### Type of change

- [X] Chore
- [ ] Feature
- [ ] Bug fix

### Why

- Update Android Gradle Plugin (AGP) to 8 
- Update Gradle to last version
- Update JDK11 by JDK17
- Increase Gradle compilation speed
- Update Cybrid Api Bank to latest version
- Upgrade Kotlin to version 1.8.10
- Upgrade Compose compiler to 1.4.3
- Fix Circle CI and add JDK17 upgrading orbs and images
- Remove prefix 'v' form releases
- Remove withSourcesJar from publishing releases - TESTED
- Remove withJavadocJar from publishing releases - TESTED